### PR TITLE
Added a test observer

### DIFF
--- a/TDD.xctemplate/___FILEBASENAME___.playground/Contents.swift
+++ b/TDD.xctemplate/___FILEBASENAME___.playground/Contents.swift
@@ -29,4 +29,20 @@ class FooTests: XCTestCase {
     }
 }
 
+class TestObserver: NSObject, XCTestObservation {
+    func testCase(_ testCase: XCTestCase,
+                  didFailWithDescription description: String,
+                  inFile filePath: String?,
+                  atLine lineNumber: Int) {
+        print("                                                                   ")
+        print("*******************************************************************")
+        print("Test failed on line \(lineNumber): \(testCase.name), \(description)")
+        print("*******************************************************************")
+        print("                                                                   ")
+    }
+}
+
+let testObserver = TestObserver()
+XCTestObservationCenter.shared.addTestObserver(testObserver)
+
 FooTests.defaultTestSuite.run()


### PR DESCRIPTION
Added a test observer that triggers an assertion failure in case of a test failure, to make failures clear and hard to miss
so console moves 
**From:**
<img width="1790" alt="Screenshot 2022-05-17 at 01 38 26" src="https://user-images.githubusercontent.com/4116539/168695105-e9883273-55f0-4fbf-a99f-0c887845df77.png">

**To:**
<img width="1779" alt="Screenshot 2022-05-17 at 01 39 20" src="https://user-images.githubusercontent.com/4116539/168695118-fd6f3af1-dfe3-4fd4-8e29-93f391a4de88.png">
